### PR TITLE
Fix server startup behavior

### DIFF
--- a/server.js
+++ b/server.js
@@ -318,7 +318,10 @@ function startServer() {
     });
 }
 
-startServer();
+// Start server only when executed directly
+if (require.main === module) {
+    startServer();
+}
 
 module.exports = {
     startServer,


### PR DESCRIPTION
## Summary
- avoid automatically starting the server when server.js is required as a module

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68798c2aa3608328bc5c20c70369957a