### PR TITLE
Fix manifest reference

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -25,7 +25,7 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["contentScript.js"],
+      "js": ["content-script.js"],
       "run_at": "document_idle"
     }
   ],


### PR DESCRIPTION
## Summary
- use `content-script.js` in manifest content script list

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879d1ac03108328871db2cf4b603265