### PR TITLE
Fix sidebar UTF-8 and dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@babel/core": "^7.24.7",
     "@babel/preset-env": "^7.24.7",
     "lint-staged": "^15.2.1",
-    "formatjs-cli": "^6.8.0"
+    "@formatjs/cli": "^6.7.2"
   },
   "lint-staged": {
     "*.js": [

--- a/sidebar.jsx
+++ b/sidebar.jsx
@@ -1,7 +1,7 @@
 const SIDEBAR_SECTIONS = [
   { id: 'dashboard', label: { en: 'Dashboard', es: 'Tablero' }, icon: '?' },
   { id: 'forms', label: { en: 'Forms', es: 'Formularios' }, icon: '?' },
-  { id: 'settings', label: { en: 'Settings', es: 'Configuraci?n' }, icon: '??' },
+  { id: 'settings', label: { en: 'Settings', es: 'Configuración' }, icon: '??' },
 ];
 
 const THEMES = ['light', 'dark'];
@@ -29,7 +29,7 @@ export default function Sidebar(props) {
     if (props.onSectionChange) props.onSectionChange(sectionId);
     triggerNotification(
       locale === 'es'
-        ? 'Secci?n cambiada'
+        ? 'Sección cambiada'
         : 'Section changed'
     );
   }
@@ -56,7 +56,7 @@ export default function Sidebar(props) {
     if (props.onLocaleChange) props.onLocaleChange(selectedLocale);
     triggerNotification(
       selectedLocale === 'es'
-        ? 'Idioma cambiado a Espa?ol'
+        ? 'Idioma cambiado a Español'
         : 'Language switched to English'
     );
   }


### PR DESCRIPTION
## Summary
- fixed Spanish accents in `sidebar.jsx`
- corrected dev dependency name to `@formatjs/cli`

## Testing
- `npm install` *(fails: cannot fetch dependencies)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879d1a909588328830e818a9e1d6a56